### PR TITLE
Develop <- fix: Deposit endpoint returning 500 Internal Server Error 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,17 @@
             <artifactId>jjwt</artifactId>
             <version>0.9.1</version>
         </dependency>
+        <!-- Dependências JAXB para compatibilidade com Java 9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+        </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>

--- a/src/main/java/com/recargapay/wallet/adapter/controllers/AuthController.java
+++ b/src/main/java/com/recargapay/wallet/adapter/controllers/AuthController.java
@@ -1,0 +1,92 @@
+package com.recargapay.wallet.adapter.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Autenticação", description = "Geração de token JWT para testes")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private static final String ERROR_KEY = "error";
+    
+    @Value("${spring.security.oauth2.resourceserver.jwt.secret}")
+    private String jwtSecret;
+    
+    private final AuthenticationManager authenticationManager;
+
+    @Operation(summary = "Realiza login e retorna um JWT para testes")
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, String>> login(@RequestBody Map<String, String> credentials) {
+        String username = credentials.get("username");
+        String password = credentials.get("password");
+        
+        // Verifica se as credenciais foram fornecidas
+        if (username == null || password == null || username.isEmpty() || password.isEmpty()) {
+            Map<String, String> response = new HashMap<>();
+            response.put(ERROR_KEY, "Username e password são obrigatórios");
+            return ResponseEntity.status(401).body(response);
+        }
+        
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(username, password)
+            );
+            
+            String token = generateToken(authentication);
+            Map<String, String> response = new HashMap<>();
+            response.put("token", token);
+            return ResponseEntity.ok(response);
+        } catch (BadCredentialsException e) {
+            Map<String, String> response = new HashMap<>();
+            response.put(ERROR_KEY, "Usuário ou senha inválidos");
+            return ResponseEntity.status(401).body(response);
+        } catch (AuthenticationException e) {
+            Map<String, String> response = new HashMap<>();
+            response.put(ERROR_KEY, "Erro de autenticação: " + e.getMessage());
+            return ResponseEntity.status(401).body(response);
+        } catch (Exception e) {
+            Map<String, String> response = new HashMap<>();
+            response.put(ERROR_KEY, "Erro interno ao processar a autenticação");
+            return ResponseEntity.status(500).body(response);
+        }
+    }
+
+    private String generateToken(Authentication authentication) {
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(60L * 60); // 1 hora
+        
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(" "));
+            
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("scope", authorities)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(exp))
+                .signWith(SignatureAlgorithm.HS256, jwtSecret.getBytes(StandardCharsets.UTF_8))
+                .compact();
+    }
+}

--- a/src/main/java/com/recargapay/wallet/adapter/controllers/v1/UserController.java
+++ b/src/main/java/com/recargapay/wallet/adapter/controllers/v1/UserController.java
@@ -1,0 +1,51 @@
+package com.recargapay.wallet.adapter.controllers.v1;
+
+import com.recargapay.wallet.adapter.converters.UserMapper;
+import com.recargapay.wallet.adapter.dtos.CreateUserRequestDTO;
+import com.recargapay.wallet.adapter.dtos.UserDTO;
+import com.recargapay.wallet.core.domain.User;
+import com.recargapay.wallet.core.ports.in.CreateUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final CreateUserUseCase createUserUseCase;
+    private final UserMapper userMapper;
+
+    public UserController(CreateUserUseCase createUserUseCase, UserMapper userMapper) {
+        this.createUserUseCase = createUserUseCase;
+        this.userMapper = userMapper;
+    }
+
+    @Operation(summary = "Criar novo usuário", responses = {
+            @ApiResponse(responseCode = "201", description = "Usuário criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Erro de validação"),
+            @ApiResponse(responseCode = "409", description = "Email já está em uso")
+    })
+    @PostMapping
+    public ResponseEntity<UserDTO> create(@Valid @RequestBody CreateUserRequestDTO dto) {
+        User user = userMapper.toDomain(dto);
+        User created = createUserUseCase.create(user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(userMapper.toDTO(created));
+    }
+
+    @Operation(summary = "Obter usuário por ID", responses = {
+            @ApiResponse(responseCode = "200", description = "Usuário retornado com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserDTO> findById(@PathVariable UUID userId) {
+        return createUserUseCase.findById(userId)
+                .map(user -> ResponseEntity.ok(userMapper.toDTO(user)))
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/recargapay/wallet/adapter/converters/TransactionMapper.java
+++ b/src/main/java/com/recargapay/wallet/adapter/converters/TransactionMapper.java
@@ -18,15 +18,35 @@ public class TransactionMapper {
     }
 
     public Transaction toDomain(TransactionEntity entity) {
-        return MapperUtils.mapIfNotNull(entity, e -> mapper.map(e, Transaction.class));
-    }
+        if (entity == null) {
+            return null;
+        }
 
-    public TransactionEntity toEntity(Transaction domain) {
-        return MapperUtils.mapIfNotNull(domain, d -> mapper.map(d, TransactionEntity.class));
+        Transaction transaction = new Transaction();
+        transaction.setId(entity.getId());
+        transaction.setAmount(entity.getAmount());
+        transaction.setWalletId(entity.getWallet() != null ? entity.getWallet().getId() : null);
+        transaction.setType(entity.getType());
+        transaction.setTimestamp(entity.getTimestamp());
+        transaction.setRelatedUserId(entity.getRelatedUserId());
+        
+        return transaction;
     }
 
     public TransactionDTO toDTO(Transaction domain) {
-        return MapperUtils.mapIfNotNull(domain, d -> mapper.map(d, TransactionDTO.class));
+        if (domain == null) {
+            return null;
+        }
+        
+        TransactionDTO dto = new TransactionDTO();
+        dto.setId(domain.getId());
+        dto.setWalletId(domain.getWalletId());
+        dto.setAmount(domain.getAmount());
+        dto.setType(domain.getType() != null ? domain.getType().toString() : null);
+        dto.setTimestamp(domain.getTimestamp());
+        dto.setRelatedUserId(domain.getRelatedUserId());
+        
+        return dto;
     }
 
     public List<TransactionDTO> toDTOList(List<Transaction> domains) {

--- a/src/main/java/com/recargapay/wallet/adapter/converters/UserMapper.java
+++ b/src/main/java/com/recargapay/wallet/adapter/converters/UserMapper.java
@@ -1,5 +1,6 @@
 package com.recargapay.wallet.adapter.converters;
 
+import com.recargapay.wallet.adapter.dtos.CreateUserRequestDTO;
 import com.recargapay.wallet.adapter.dtos.UserDTO;
 import com.recargapay.wallet.adapter.entities.UserEntity;
 import com.recargapay.wallet.core.domain.User;
@@ -28,8 +29,17 @@ public class UserMapper {
     public UserDTO toDTO(User domain) {
         return MapperUtils.mapIfNotNull(domain, d -> mapper.map(d, UserDTO.class));
     }
-
+    
     public List<UserDTO> toDTOList(List<User> domains) {
         return Objects.requireNonNullElse(domains, List.<User>of()).stream().map(this::toDTO).toList();
+    }
+    
+    // Conversão de CreateUserRequestDTO para domínio User
+    public User toDomain(CreateUserRequestDTO dto) {
+        if (dto == null) return null;
+        User user = new User();
+        user.setName(dto.getName());
+        user.setEmail(dto.getEmail());
+        return user;
     }
 }

--- a/src/main/java/com/recargapay/wallet/adapter/dtos/CreateUserRequestDTO.java
+++ b/src/main/java/com/recargapay/wallet/adapter/dtos/CreateUserRequestDTO.java
@@ -1,0 +1,19 @@
+package com.recargapay.wallet.adapter.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateUserRequestDTO {
+    @NotBlank(message = "Nome é obrigatório")
+    private String name;
+    
+    @NotBlank(message = "Email é obrigatório")
+    @Email(message = "Formato de email inválido")
+    private String email;
+}

--- a/src/main/java/com/recargapay/wallet/adapter/entities/WalletEntity.java
+++ b/src/main/java/com/recargapay/wallet/adapter/entities/WalletEntity.java
@@ -28,9 +28,20 @@ public class WalletEntity {
     @Column(nullable = false)
     private BigDecimal balance;
 
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
 
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/recargapay/wallet/adapter/repositories/UserJpaRepository.java
+++ b/src/main/java/com/recargapay/wallet/adapter/repositories/UserJpaRepository.java
@@ -2,7 +2,9 @@ package com.recargapay.wallet.adapter.repositories;
 
 import com.recargapay.wallet.adapter.entities.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/com/recargapay/wallet/adapter/repositories/WalletJpaRepository.java
+++ b/src/main/java/com/recargapay/wallet/adapter/repositories/WalletJpaRepository.java
@@ -2,7 +2,9 @@ package com.recargapay.wallet.adapter.repositories;
 
 import com.recargapay.wallet.adapter.entities.WalletEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface WalletJpaRepository extends JpaRepository<WalletEntity, UUID> {
+    Optional<WalletEntity> findByUser_Id(UUID userId);
 }

--- a/src/main/java/com/recargapay/wallet/adapter/repositories/impl/TransactionRepositoryImpl.java
+++ b/src/main/java/com/recargapay/wallet/adapter/repositories/impl/TransactionRepositoryImpl.java
@@ -3,8 +3,11 @@ package com.recargapay.wallet.adapter.repositories.impl;
 import com.recargapay.wallet.core.domain.Transaction;
 import com.recargapay.wallet.core.ports.out.TransactionRepository;
 import com.recargapay.wallet.adapter.entities.TransactionEntity;
+import com.recargapay.wallet.adapter.entities.WalletEntity;
 import com.recargapay.wallet.adapter.repositories.TransactionJpaRepository;
+import com.recargapay.wallet.adapter.repositories.WalletJpaRepository;
 import com.recargapay.wallet.adapter.converters.TransactionMapper;
+import com.recargapay.wallet.core.exceptions.WalletNotFoundException;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,21 +18,26 @@ import java.util.UUID;
 public class TransactionRepositoryImpl implements TransactionRepository {
 
     private final TransactionJpaRepository jpaRepository;
+    private final WalletJpaRepository walletJpaRepository;
     private final TransactionMapper transactionMapper;
 
-    public TransactionRepositoryImpl(TransactionJpaRepository jpaRepository, TransactionMapper transactionMapper) {
+    public TransactionRepositoryImpl(TransactionJpaRepository jpaRepository, 
+                                    WalletJpaRepository walletJpaRepository,
+                                    TransactionMapper transactionMapper) {
         this.jpaRepository = jpaRepository;
+        this.walletJpaRepository = walletJpaRepository;
         this.transactionMapper = transactionMapper;
     }
 
     @Override
     public void save(Transaction transaction) {
-        jpaRepository.save(transactionMapper.toEntity(transaction));
+        TransactionEntity entity = toEntity(transaction);
+        jpaRepository.save(entity);
     }
 
     @Override
     public Transaction saveAndReturn(Transaction transaction) {
-        TransactionEntity entity = transactionMapper.toEntity(transaction);
+        TransactionEntity entity = toEntity(transaction);
         TransactionEntity saved = jpaRepository.save(entity);
         return transactionMapper.toDomain(saved);
     }
@@ -49,5 +57,26 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         return jpaRepository.findAll().stream().map(transactionMapper::toDomain).toList();
     }
 
-    
+    private TransactionEntity toEntity(Transaction domain) {
+        if (domain == null) {
+            return null;
+        }
+        
+        TransactionEntity entity = new TransactionEntity();
+        entity.setId(domain.getId());
+        entity.setAmount(domain.getAmount());
+        
+        // Buscar a wallet pelo ID para estabelecer a relação
+        if (domain.getWalletId() != null) {
+            WalletEntity walletEntity = walletJpaRepository.findById(domain.getWalletId())
+                .orElseThrow(() -> new WalletNotFoundException("Wallet not found: " + domain.getWalletId()));
+            entity.setWallet(walletEntity);
+        }
+        
+        entity.setType(domain.getType());
+        entity.setTimestamp(domain.getTimestamp());
+        entity.setRelatedUserId(domain.getRelatedUserId());
+        
+        return entity;
+    }
 }

--- a/src/main/java/com/recargapay/wallet/adapter/repositories/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/recargapay/wallet/adapter/repositories/impl/UserRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.recargapay.wallet.adapter.repositories.impl;
+
+import com.recargapay.wallet.adapter.converters.UserMapper;
+import com.recargapay.wallet.adapter.entities.UserEntity;
+import com.recargapay.wallet.adapter.repositories.UserJpaRepository;
+import com.recargapay.wallet.core.domain.User;
+import com.recargapay.wallet.core.ports.out.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+    private final UserMapper userMapper;
+
+    public UserRepositoryImpl(UserJpaRepository jpaRepository, UserMapper userMapper) {
+        this.jpaRepository = jpaRepository;
+        this.userMapper = userMapper;
+    }
+
+    @Override
+    public Optional<User> findById(UUID userId) {
+        return jpaRepository.findById(userId).map(userMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaRepository.findByEmail(email).map(userMapper::toDomain);
+    }
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = userMapper.toEntity(user);
+        UserEntity saved = jpaRepository.save(entity);
+        return userMapper.toDomain(saved);
+    }
+
+    @Override
+    public void update(User user) {
+        jpaRepository.save(userMapper.toEntity(user));
+    }
+
+    @Override
+    public void delete(UUID userId) {
+        jpaRepository.deleteById(userId);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return jpaRepository.findAll().stream().map(userMapper::toDomain).toList();
+    }
+}

--- a/src/main/java/com/recargapay/wallet/adapter/repositories/impl/WalletRepositoryImpl.java
+++ b/src/main/java/com/recargapay/wallet/adapter/repositories/impl/WalletRepositoryImpl.java
@@ -31,6 +31,11 @@ public class WalletRepositoryImpl implements WalletRepository {
     }
 
     @Override
+    public Optional<Wallet> findByUserId(UUID userId) {
+        return jpaRepository.findByUser_Id(userId).map(walletMapper::toDomain);
+    }
+
+    @Override
     public void update(Wallet wallet) {
         jpaRepository.save(toEntity(wallet));
     }

--- a/src/main/java/com/recargapay/wallet/core/exceptions/DuplicatedResourceException.java
+++ b/src/main/java/com/recargapay/wallet/core/exceptions/DuplicatedResourceException.java
@@ -1,0 +1,12 @@
+package com.recargapay.wallet.core.exceptions;
+
+public class DuplicatedResourceException extends RuntimeException {
+    
+    public DuplicatedResourceException(String message) {
+        super(message);
+    }
+    
+    public DuplicatedResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/recargapay/wallet/core/ports/in/CreateUserUseCase.java
+++ b/src/main/java/com/recargapay/wallet/core/ports/in/CreateUserUseCase.java
@@ -1,0 +1,11 @@
+package com.recargapay.wallet.core.ports.in;
+
+import com.recargapay.wallet.core.domain.User;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CreateUserUseCase {
+    User create(User user);
+    Optional<User> findById(UUID userId);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/recargapay/wallet/core/ports/out/UserRepository.java
+++ b/src/main/java/com/recargapay/wallet/core/ports/out/UserRepository.java
@@ -1,0 +1,15 @@
+package com.recargapay.wallet.core.ports.out;
+
+import com.recargapay.wallet.core.domain.User;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    Optional<User> findById(UUID userId);
+    Optional<User> findByEmail(String email);
+    User save(User user);
+    void update(User user);
+    void delete(UUID userId);
+    List<User> findAll();
+}

--- a/src/main/java/com/recargapay/wallet/core/ports/out/WalletRepository.java
+++ b/src/main/java/com/recargapay/wallet/core/ports/out/WalletRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public interface WalletRepository {
     Optional<Wallet> findById(UUID walletId);
+    Optional<Wallet> findByUserId(UUID userId);
     void update(Wallet wallet);
     Wallet save(Wallet wallet);
     void delete(UUID walletId);

--- a/src/main/java/com/recargapay/wallet/core/services/CreateUserService.java
+++ b/src/main/java/com/recargapay/wallet/core/services/CreateUserService.java
@@ -1,0 +1,42 @@
+package com.recargapay.wallet.core.services;
+
+import com.recargapay.wallet.core.domain.User;
+import com.recargapay.wallet.core.exceptions.DuplicatedResourceException;
+import com.recargapay.wallet.core.ports.in.CreateUserUseCase;
+import com.recargapay.wallet.core.ports.out.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class CreateUserService implements CreateUserUseCase {
+    private final UserRepository userRepository;
+
+    public CreateUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public User create(User user) {
+        // Verificar se o e-mail já está em uso
+        if (user.getEmail() != null && userRepository.findByEmail(user.getEmail()).isPresent()) {
+            throw new DuplicatedResourceException("E-mail já está em uso: " + user.getEmail());
+        }
+        
+        // Aqui pode-se adicionar validações de negócio, se necessário
+        return userRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(UUID userId) {
+        return userRepository.findById(userId);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+}

--- a/src/main/java/com/recargapay/wallet/core/services/CreateWalletService.java
+++ b/src/main/java/com/recargapay/wallet/core/services/CreateWalletService.java
@@ -1,8 +1,11 @@
 package com.recargapay.wallet.core.services;
 
 import com.recargapay.wallet.core.domain.Wallet;
+import com.recargapay.wallet.core.exceptions.UserNotFoundException;
+import com.recargapay.wallet.core.exceptions.WalletAlreadyExistsException;
 import com.recargapay.wallet.core.exceptions.WalletNotFoundException;
 import com.recargapay.wallet.core.ports.in.CreateWalletUseCase;
+import com.recargapay.wallet.core.ports.out.UserRepository;
 import com.recargapay.wallet.core.ports.out.WalletRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,15 +14,26 @@ import java.util.UUID;
 @Service
 public class CreateWalletService implements CreateWalletUseCase {
     private final WalletRepository walletRepository;
+    private final UserRepository userRepository;
 
-    public CreateWalletService(WalletRepository walletRepository) {
+    public CreateWalletService(WalletRepository walletRepository, UserRepository userRepository) {
         this.walletRepository = walletRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
     @Transactional
     public Wallet create(Wallet wallet) {
-        // Aqui pode-se adicionar validações de negócio, se necessário
+        // Validar se o usuário existe antes de criar a carteira
+        if (!userRepository.findById(wallet.getUserId()).isPresent()) {
+            throw new UserNotFoundException("Usuário não encontrado: " + wallet.getUserId());
+        }
+        
+        // Verificar se o usuário já possui uma carteira
+        if (walletRepository.findByUserId(wallet.getUserId()).isPresent()) {
+            throw new WalletAlreadyExistsException("Usuário já possui uma carteira: " + wallet.getUserId());
+        }
+        
         return walletRepository.save(wallet);
     }
 

--- a/src/main/java/com/recargapay/wallet/infra/config/JwtDecoderConfig.java
+++ b/src/main/java/com/recargapay/wallet/infra/config/JwtDecoderConfig.java
@@ -3,11 +3,13 @@ package com.recargapay.wallet.infra.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 import javax.crypto.spec.SecretKeySpec;
 
+@Profile("!test")
 @Configuration
 public class JwtDecoderConfig {
 

--- a/src/main/java/com/recargapay/wallet/infra/config/ModelMapperConfig.java
+++ b/src/main/java/com/recargapay/wallet/infra/config/ModelMapperConfig.java
@@ -1,6 +1,9 @@
 package com.recargapay.wallet.infra.config;
 
+import com.recargapay.wallet.core.domain.TransactionType;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +11,27 @@ import org.springframework.context.annotation.Configuration;
 public class ModelMapperConfig {
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper modelMapper = new ModelMapper();
+        
+        // Configuração para tornar o mapeamento mais restrito
+        modelMapper.getConfiguration()
+                .setMatchingStrategy(MatchingStrategies.STRICT)
+                .setSkipNullEnabled(true);
+        
+        // Converter para transformar enum TransactionType em String
+        Converter<TransactionType, String> transactionTypeToStringConverter = 
+            ctx -> ctx.getSource() == null ? null : ctx.getSource().toString();
+        
+        // Converter para transformar String em enum TransactionType
+        Converter<String, TransactionType> stringToTransactionTypeConverter = 
+            ctx -> ctx.getSource() == null ? null : TransactionType.valueOf(ctx.getSource());
+            
+        // Registrar os conversores
+        modelMapper.createTypeMap(TransactionType.class, String.class)
+                .setConverter(transactionTypeToStringConverter);
+        modelMapper.createTypeMap(String.class, TransactionType.class)
+                .setConverter(stringToTransactionTypeConverter);
+                
+        return modelMapper;
     }
 }

--- a/src/main/java/com/recargapay/wallet/infra/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/recargapay/wallet/infra/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.recargapay.wallet.infra.handler;
 
+import com.recargapay.wallet.core.exceptions.DuplicatedResourceException;
 import com.recargapay.wallet.core.exceptions.InsufficientBalanceException;
 import com.recargapay.wallet.core.exceptions.UserNotFoundException;
 import com.recargapay.wallet.core.exceptions.WalletNotFoundException;
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleUserNotFound(UserNotFoundException ex) {
         log.warn("User not found: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(DuplicatedResourceException.class)
+    public ResponseEntity<String> handleDuplicatedResource(DuplicatedResourceException ex) {
+        log.warn("Duplicated resource: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/test/java/com/recargapay/wallet/adapter/controllers/AuthControllerTest.java
+++ b/src/test/java/com/recargapay/wallet/adapter/controllers/AuthControllerTest.java
@@ -1,0 +1,162 @@
+package com.recargapay.wallet.adapter.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+    
+    private ObjectMapper objectMapper = new ObjectMapper();
+    
+    @Mock
+    private AuthenticationManager authenticationManager;
+    
+    @InjectMocks
+    private AuthController authController;
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        
+        // Injetar manualmente o valor do JWT secret
+        try {
+            java.lang.reflect.Field field = AuthController.class.getDeclaredField("jwtSecret");
+            field.setAccessible(true);
+            field.set(authController, "testsecret");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        
+        ExceptionHandlerExceptionResolver exceptionResolver = new ExceptionHandlerExceptionResolver();
+        exceptionResolver.afterPropertiesSet();
+        
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(authController)
+                .setHandlerExceptionResolvers(exceptionResolver)
+                .build();
+    }
+
+    @Test
+    void login_withValidCredentials_returnsToken() throws Exception {
+        // Arrange
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put("username", "admin");
+        credentials.put("password", "admin123");
+        
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+            "admin", 
+            null, 
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credentials)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").exists());
+    }
+
+    @Test
+    void login_withInvalidCredentials_returns401() throws Exception {
+        // Arrange
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put("username", "wrong");
+        credentials.put("password", "wrong");
+        
+        when(authenticationManager.authenticate(any()))
+            .thenThrow(new BadCredentialsException("Bad credentials"));
+        
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credentials)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error").value("Usuário ou senha inválidos"));
+    }
+    
+    @Test
+    void login_withAuthenticationException_returns401() throws Exception {
+        // Arrange
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put("username", "locked");
+        credentials.put("password", "password");
+        
+        // Uma exceção de autenticação diferente de BadCredentialsException
+        when(authenticationManager.authenticate(any()))
+            .thenThrow(new TestAuthenticationException("Conta bloqueada"));
+        
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credentials)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error").value("Erro de autenticação: Conta bloqueada"));
+    }
+    
+    @Test
+    void login_withGenericException_returns500() throws Exception {
+        // Arrange
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put("username", "admin");
+        credentials.put("password", "admin123");
+        
+        // Uma exceção genérica que não é de autenticação
+        when(authenticationManager.authenticate(any()))
+            .thenThrow(new RuntimeException("Erro interno do servidor"));
+        
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credentials)))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.error").value("Erro interno ao processar a autenticação"));
+    }
+    
+    @Test
+    void login_withMissingCredentials_returns401() throws Exception {
+        // Arrange
+        Map<String, String> credentials = new HashMap<>();
+        // Não incluindo username e password
+        
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credentials)))
+            .andExpect(status().isUnauthorized());
+    }
+    
+    // Classe auxiliar para teste de exceção de autenticação personalizada
+    private static class TestAuthenticationException extends AuthenticationException {
+        public TestAuthenticationException(String msg) {
+            super(msg);
+        }
+    }
+}

--- a/src/test/java/com/recargapay/wallet/adapter/controllers/v1/TestSecurityConfig.java
+++ b/src/test/java/com/recargapay/wallet/adapter/controllers/v1/TestSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.recargapay.wallet.adapter.controllers.v1;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // Configuração simplificada para testes usando apenas autenticação mock
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authz -> authz
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/src/test/java/com/recargapay/wallet/adapter/controllers/v1/UserControllerTest.java
+++ b/src/test/java/com/recargapay/wallet/adapter/controllers/v1/UserControllerTest.java
@@ -1,0 +1,158 @@
+package com.recargapay.wallet.adapter.controllers.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recargapay.wallet.adapter.converters.UserMapper;
+import com.recargapay.wallet.adapter.dtos.CreateUserRequestDTO;
+import com.recargapay.wallet.adapter.dtos.UserDTO;
+import com.recargapay.wallet.core.domain.User;
+import com.recargapay.wallet.core.exceptions.DuplicatedResourceException;
+import com.recargapay.wallet.core.ports.in.CreateUserUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import({TestSecurityConfig.class, UserControllerTest.TestConfig.class})
+class UserControllerTest {
+
+    // Config interna para fornecer os mocks necessários
+    static class TestConfig {
+        @Bean
+        public CreateUserUseCase createUserUseCase() {
+            return mock(CreateUserUseCase.class);
+        }
+
+        @Bean
+        public UserMapper userMapper() {
+            return mock(UserMapper.class);
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CreateUserUseCase createUserUseCase;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void create_ShouldReturnCreatedUser_WhenValidRequestProvided() throws Exception {
+        // Arrange
+        CreateUserRequestDTO requestDTO = new CreateUserRequestDTO("Test User", "test@example.com");
+        
+        User user = new User();
+        user.setName("Test User");
+        user.setEmail("test@example.com");
+        
+        User createdUser = new User();
+        createdUser.setId(UUID.randomUUID());
+        createdUser.setName("Test User");
+        createdUser.setEmail("test@example.com");
+        
+        UserDTO userDTO = new UserDTO(createdUser.getId(), createdUser.getEmail(), createdUser.getName());
+
+        when(userMapper.toDomain(any(CreateUserRequestDTO.class))).thenReturn(user);
+        when(createUserUseCase.create(any(User.class))).thenReturn(createdUser);
+        when(userMapper.toDTO(any(User.class))).thenReturn(userDTO);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(createdUser.getId().toString()))
+                .andExpect(jsonPath("$.name").value("Test User"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void create_ShouldReturnBadRequest_WhenInvalidRequestProvided() throws Exception {
+        // Arrange
+        CreateUserRequestDTO requestDTO = new CreateUserRequestDTO("", ""); // Nome e email vazios
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void create_ShouldReturnConflict_WhenEmailAlreadyExists() throws Exception {
+        // Arrange
+        CreateUserRequestDTO requestDTO = new CreateUserRequestDTO("Test User", "existing@example.com");
+        
+        User user = new User();
+        user.setName("Test User");
+        user.setEmail("existing@example.com");
+
+        when(userMapper.toDomain(any(CreateUserRequestDTO.class))).thenReturn(user);
+        when(createUserUseCase.create(any(User.class))).thenThrow(new DuplicatedResourceException("Email já está em uso"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void findById_ShouldReturnUser_WhenUserExists() throws Exception {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        
+        User user = new User();
+        user.setId(userId);
+        user.setName("Test User");
+        user.setEmail("test@example.com");
+        
+        UserDTO userDTO = new UserDTO(userId, "test@example.com", "Test User");
+
+        when(createUserUseCase.findById(userId)).thenReturn(Optional.of(user));
+        when(userMapper.toDTO(user)).thenReturn(userDTO);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/users/" + userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.name").value("Test User"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void findById_ShouldReturnNotFound_WhenUserDoesNotExist() throws Exception {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        when(createUserUseCase.findById(userId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/users/" + userId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/recargapay/wallet/adapter/converters/UserMapperTest.java
+++ b/src/test/java/com/recargapay/wallet/adapter/converters/UserMapperTest.java
@@ -1,5 +1,6 @@
 package com.recargapay.wallet.adapter.converters;
 
+import com.recargapay.wallet.adapter.dtos.CreateUserRequestDTO;
 import com.recargapay.wallet.adapter.dtos.UserDTO;
 import com.recargapay.wallet.adapter.entities.UserEntity;
 import com.recargapay.wallet.core.domain.User;
@@ -37,6 +38,12 @@ class UserMapperTest {
     }
 
     @Test
+    void toDomain_shouldReturnNullForNullEntity() {
+        User user = mapper.toDomain((UserEntity) null);
+        assertNull(user);
+    }
+
+    @Test
     void toEntity_shouldMapFields() {
         UUID id = UUID.randomUUID();
         String email = "test@example.com";
@@ -50,6 +57,12 @@ class UserMapperTest {
     }
 
     @Test
+    void toEntity_shouldReturnNullForNullDomain() {
+        UserEntity entity = mapper.toEntity(null);
+        assertNull(entity);
+    }
+
+    @Test
     void toDTO_shouldMapFields() {
         UUID id = UUID.randomUUID();
         String email = "test@example.com";
@@ -60,6 +73,12 @@ class UserMapperTest {
         assertEquals(id, dto.getId());
         assertEquals(email, dto.getEmail());
         assertEquals(name, dto.getName());
+    }
+
+    @Test
+    void toDTO_shouldReturnNullForNullDomain() {
+        UserDTO dto = mapper.toDTO(null);
+        assertNull(dto);
     }
 
     @Test
@@ -81,5 +100,31 @@ class UserMapperTest {
         List<UserDTO> dtos = mapper.toDTOList(null);
         assertNotNull(dtos);
         assertTrue(dtos.isEmpty());
+    }
+    
+    @Test
+    void toDomain_ShouldMapCreateRequestDTOToUser_WhenValidRequestProvided() {
+        // Arrange
+        String name = "Test User";
+        String email = "test@example.com";
+        CreateUserRequestDTO dto = new CreateUserRequestDTO(name, email);
+        
+        // Act
+        User user = mapper.toDomain(dto);
+        
+        // Assert
+        assertNotNull(user);
+        assertEquals(name, user.getName());
+        assertEquals(email, user.getEmail());
+        assertNull(user.getId()); // ID should be null as it's a new user
+    }
+    
+    @Test
+    void toDomain_ShouldReturnNull_WhenCreateRequestDTOIsNull() {
+        // Act
+        User user = mapper.toDomain((CreateUserRequestDTO) null);
+        
+        // Assert
+        assertNull(user);
     }
 }

--- a/src/test/java/com/recargapay/wallet/adapter/entities/WalletEntityTest.java
+++ b/src/test/java/com/recargapay/wallet/adapter/entities/WalletEntityTest.java
@@ -76,4 +76,43 @@ class WalletEntityTest {
         assertNull(entity.getCreatedAt());
         assertNull(entity.getUpdatedAt());
     }
+    
+    @Test
+    void testPrePersistSetsCreatedAtAndUpdatedAt() {
+        // Arrange
+        WalletEntity entity = new WalletEntity();
+        assertNull(entity.getCreatedAt());
+        assertNull(entity.getUpdatedAt());
+        
+        // Act
+        entity.onCreate();
+        
+        // Assert
+        assertNotNull(entity.getCreatedAt());
+        assertNotNull(entity.getUpdatedAt());
+        // Ambos devem ser definidos com o mesmo timestamp ou próximos
+        assertTrue(entity.getUpdatedAt().equals(entity.getCreatedAt()) || 
+                   entity.getUpdatedAt().isAfter(entity.getCreatedAt()));
+    }
+    
+    @Test
+    void testPreUpdateSetsUpdatedAt() {
+        // Arrange
+        WalletEntity entity = new WalletEntity();
+        entity.onCreate(); // Preenche created_at e updated_at inicialmente
+        LocalDateTime originalCreatedAt = entity.getCreatedAt();
+        LocalDateTime originalUpdatedAt = entity.getUpdatedAt();
+        
+        // Forçar uma data de atualização anterior para simular passagem de tempo
+        LocalDateTime olderDate = originalUpdatedAt.minusSeconds(10);
+        entity.setUpdatedAt(olderDate);
+        
+        // Act
+        entity.onUpdate();
+        
+        // Assert
+        assertEquals(originalCreatedAt, entity.getCreatedAt()); // created_at não deve mudar
+        assertNotEquals(olderDate, entity.getUpdatedAt()); // updated_at deve mudar
+        assertTrue(entity.getUpdatedAt().isAfter(olderDate)); // novo updated_at deve ser após o original
+    }
 }

--- a/src/test/java/com/recargapay/wallet/adapter/repositories/impl/UserRepositoryImplTest.java
+++ b/src/test/java/com/recargapay/wallet/adapter/repositories/impl/UserRepositoryImplTest.java
@@ -1,0 +1,196 @@
+package com.recargapay.wallet.adapter.repositories.impl;
+
+import com.recargapay.wallet.adapter.converters.UserMapper;
+import com.recargapay.wallet.adapter.entities.UserEntity;
+import com.recargapay.wallet.adapter.repositories.UserJpaRepository;
+import com.recargapay.wallet.core.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryImplTest {
+
+    @Mock
+    private UserJpaRepository jpaRepository;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserRepositoryImpl userRepository;
+
+    private UUID userId;
+    private User user;
+    private UserEntity userEntity;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+
+        user = new User();
+        user.setId(userId);
+        user.setName("Test User");
+        user.setEmail("test@example.com");
+
+        userEntity = new UserEntity();
+        userEntity.setId(userId);
+        userEntity.setName("Test User");
+        userEntity.setEmail("test@example.com");
+    }
+
+    @Test
+    void findById_ShouldReturnUser_WhenUserExists() {
+        // Arrange
+        when(jpaRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(userMapper.toDomain(userEntity)).thenReturn(user);
+
+        // Act
+        Optional<User> result = userRepository.findById(userId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(user, result.get());
+        verify(jpaRepository).findById(userId);
+        verify(userMapper).toDomain(userEntity);
+    }
+
+    @Test
+    void findById_ShouldReturnEmptyOptional_WhenUserDoesNotExist() {
+        // Arrange
+        when(jpaRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<User> result = userRepository.findById(userId);
+
+        // Assert
+        assertTrue(result.isEmpty());
+        verify(jpaRepository).findById(userId);
+        verify(userMapper, never()).toDomain(any(UserEntity.class));
+    }
+
+    @Test
+    void findByEmail_ShouldReturnUser_WhenUserExists() {
+        // Arrange
+        String email = "test@example.com";
+        when(jpaRepository.findByEmail(email)).thenReturn(Optional.of(userEntity));
+        when(userMapper.toDomain(userEntity)).thenReturn(user);
+
+        // Act
+        Optional<User> result = userRepository.findByEmail(email);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(user, result.get());
+        verify(jpaRepository).findByEmail(email);
+        verify(userMapper).toDomain(userEntity);
+    }
+
+    @Test
+    void findByEmail_ShouldReturnEmptyOptional_WhenUserDoesNotExist() {
+        // Arrange
+        String email = "nonexistent@example.com";
+        when(jpaRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<User> result = userRepository.findByEmail(email);
+
+        // Assert
+        assertTrue(result.isEmpty());
+        verify(jpaRepository).findByEmail(email);
+        verify(userMapper, never()).toDomain(any(UserEntity.class));
+    }
+
+    @Test
+    void save_ShouldReturnSavedUser() {
+        // Arrange
+        when(userMapper.toEntity(user)).thenReturn(userEntity);
+        when(jpaRepository.save(userEntity)).thenReturn(userEntity);
+        when(userMapper.toDomain(userEntity)).thenReturn(user);
+
+        // Act
+        User result = userRepository.save(user);
+
+        // Assert
+        assertEquals(user, result);
+        verify(userMapper).toEntity(user);
+        verify(jpaRepository).save(userEntity);
+        verify(userMapper).toDomain(userEntity);
+    }
+
+    @Test
+    void update_ShouldCallSaveMethod() {
+        // Arrange
+        when(userMapper.toEntity(user)).thenReturn(userEntity);
+
+        // Act
+        userRepository.update(user);
+
+        // Assert
+        verify(userMapper).toEntity(user);
+        verify(jpaRepository).save(userEntity);
+    }
+
+    @Test
+    void delete_ShouldCallDeleteByIdMethod() {
+        // Act
+        userRepository.delete(userId);
+
+        // Assert
+        verify(jpaRepository).deleteById(userId);
+    }
+
+    @Test
+    void findAll_ShouldReturnAllUsers() {
+        // Arrange
+        UserEntity userEntity2 = new UserEntity();
+        userEntity2.setId(UUID.randomUUID());
+        userEntity2.setName("Another User");
+        userEntity2.setEmail("another@example.com");
+
+        User user2 = new User();
+        user2.setId(userEntity2.getId());
+        user2.setName(userEntity2.getName());
+        user2.setEmail(userEntity2.getEmail());
+
+        List<UserEntity> userEntities = Arrays.asList(userEntity, userEntity2);
+        when(jpaRepository.findAll()).thenReturn(userEntities);
+        when(userMapper.toDomain(userEntity)).thenReturn(user);
+        when(userMapper.toDomain(userEntity2)).thenReturn(user2);
+
+        // Act
+        List<User> result = userRepository.findAll();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals(user, result.get(0));
+        assertEquals(user2, result.get(1));
+        verify(jpaRepository).findAll();
+        verify(userMapper, times(2)).toDomain(any(UserEntity.class));
+    }
+
+    @Test
+    void findAll_ShouldReturnEmptyList_WhenNoUsersExist() {
+        // Arrange
+        when(jpaRepository.findAll()).thenReturn(List.of());
+
+        // Act
+        List<User> result = userRepository.findAll();
+
+        // Assert
+        assertTrue(result.isEmpty());
+        verify(jpaRepository).findAll();
+    }
+}

--- a/src/test/java/com/recargapay/wallet/core/exceptions/DuplicatedResourceExceptionTest.java
+++ b/src/test/java/com/recargapay/wallet/core/exceptions/DuplicatedResourceExceptionTest.java
@@ -1,0 +1,32 @@
+package com.recargapay.wallet.core.exceptions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DuplicatedResourceExceptionTest {
+
+    private static final String ERROR_MESSAGE = "Resource already exists";
+    private static final Exception CAUSE = new RuntimeException("Original cause");
+
+    @Test
+    void constructor_ShouldCreateExceptionWithMessage_WhenOnlyMessageProvided() {
+        // Arrange & Act
+        DuplicatedResourceException exception = new DuplicatedResourceException(ERROR_MESSAGE);
+        
+        // Assert
+        assertEquals(ERROR_MESSAGE, exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void constructor_ShouldCreateExceptionWithMessageAndCause_WhenBothProvided() {
+        // Arrange & Act
+        DuplicatedResourceException exception = new DuplicatedResourceException(ERROR_MESSAGE, CAUSE);
+        
+        // Assert
+        assertEquals(ERROR_MESSAGE, exception.getMessage());
+        assertEquals(CAUSE, exception.getCause());
+    }
+}

--- a/src/test/java/com/recargapay/wallet/core/services/CreateUserServiceTest.java
+++ b/src/test/java/com/recargapay/wallet/core/services/CreateUserServiceTest.java
@@ -1,0 +1,151 @@
+package com.recargapay.wallet.core.services;
+
+import com.recargapay.wallet.core.domain.User;
+import com.recargapay.wallet.core.exceptions.DuplicatedResourceException;
+import com.recargapay.wallet.core.ports.out.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateUserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CreateUserService createUserService;
+
+    @BeforeEach
+    void setUp() {
+        createUserService = new CreateUserService(userRepository);
+    }
+
+    @Test
+    void create_ShouldReturnCreatedUser_WhenValidUserProvided() {
+        // Arrange
+        User userToCreate = new User();
+        userToCreate.setName("Test User");
+        userToCreate.setEmail("test@example.com");
+
+        User createdUser = new User();
+        createdUser.setId(UUID.randomUUID());
+        createdUser.setName("Test User");
+        createdUser.setEmail("test@example.com");
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(createdUser);
+
+        // Act
+        User result = createUserService.create(userToCreate);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(createdUser.getId(), result.getId());
+        assertEquals("Test User", result.getName());
+        assertEquals("test@example.com", result.getEmail());
+        verify(userRepository).findByEmail("test@example.com");
+        verify(userRepository).save(userToCreate);
+    }
+
+    @Test
+    void create_ShouldThrowDuplicatedResourceException_WhenEmailAlreadyExists() {
+        // Arrange
+        User existingUser = new User();
+        existingUser.setId(UUID.randomUUID());
+        existingUser.setName("Existing User");
+        existingUser.setEmail("existing@example.com");
+
+        User userToCreate = new User();
+        userToCreate.setName("New User");
+        userToCreate.setEmail("existing@example.com");
+
+        when(userRepository.findByEmail("existing@example.com")).thenReturn(Optional.of(existingUser));
+
+        // Act & Assert
+        assertThrows(DuplicatedResourceException.class, () -> {
+            createUserService.create(userToCreate);
+        });
+        verify(userRepository).findByEmail("existing@example.com");
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void findById_ShouldReturnUser_WhenUserExists() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        User existingUser = new User();
+        existingUser.setId(userId);
+        existingUser.setName("Test User");
+        existingUser.setEmail("test@example.com");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(existingUser));
+
+        // Act
+        Optional<User> result = createUserService.findById(userId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(userId, result.get().getId());
+        assertEquals("Test User", result.get().getName());
+        assertEquals("test@example.com", result.get().getEmail());
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    void findById_ShouldReturnEmpty_WhenUserDoesNotExist() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<User> result = createUserService.findById(userId);
+
+        // Assert
+        assertTrue(result.isEmpty());
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    void findByEmail_ShouldReturnUser_WhenUserExists() {
+        // Arrange
+        String email = "test@example.com";
+        User existingUser = new User();
+        existingUser.setId(UUID.randomUUID());
+        existingUser.setName("Test User");
+        existingUser.setEmail(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(existingUser));
+
+        // Act
+        Optional<User> result = createUserService.findByEmail(email);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(email, result.get().getEmail());
+        assertEquals("Test User", result.get().getName());
+        verify(userRepository).findByEmail(email);
+    }
+
+    @Test
+    void findByEmail_ShouldReturnEmpty_WhenUserDoesNotExist() {
+        // Arrange
+        String email = "nonexistent@example.com";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<User> result = createUserService.findByEmail(email);
+
+        // Assert
+        assertTrue(result.isEmpty());
+        verify(userRepository).findByEmail(email);
+    }
+}

--- a/src/test/java/com/recargapay/wallet/core/services/CreateWalletServiceTest.java
+++ b/src/test/java/com/recargapay/wallet/core/services/CreateWalletServiceTest.java
@@ -1,10 +1,15 @@
 package com.recargapay.wallet.core.services;
 
+import com.recargapay.wallet.core.domain.User;
 import com.recargapay.wallet.core.domain.Wallet;
+import com.recargapay.wallet.core.exceptions.UserNotFoundException;
+import com.recargapay.wallet.core.exceptions.WalletAlreadyExistsException;
+import com.recargapay.wallet.core.ports.out.UserRepository;
 import com.recargapay.wallet.core.ports.out.WalletRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,20 +17,78 @@ import static org.mockito.Mockito.*;
 
 class CreateWalletServiceTest {
     private WalletRepository walletRepository;
+    private UserRepository userRepository;
     private CreateWalletService service;
 
     @BeforeEach
     void setUp() {
         walletRepository = mock(WalletRepository.class);
-        service = new CreateWalletService(walletRepository);
+        userRepository = mock(UserRepository.class);
+        service = new CreateWalletService(walletRepository, userRepository);
     }
 
     @Test
     void shouldCreateWalletSuccessfully() {
-        Wallet wallet = new Wallet(UUID.randomUUID(), UUID.randomUUID(), null);
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Wallet wallet = new Wallet(UUID.randomUUID(), userId, null);
+        User user = new User();
+        user.setId(userId);
+        
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(walletRepository.findByUserId(userId)).thenReturn(Optional.empty());
         when(walletRepository.save(wallet)).thenReturn(wallet);
+        
+        // Act
         Wallet created = service.create(wallet);
+        
+        // Assert
         assertEquals(wallet, created);
+        verify(userRepository).findById(userId);
+        verify(walletRepository).findByUserId(userId);
         verify(walletRepository).save(wallet);
+    }
+    
+    @Test
+    void shouldThrowExceptionWhenUserNotFound() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Wallet wallet = new Wallet(UUID.randomUUID(), userId, null);
+        
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        
+        // Act & Assert
+        UserNotFoundException exception = assertThrows(
+            UserNotFoundException.class,
+            () -> service.create(wallet)
+        );
+        
+        assertTrue(exception.getMessage().contains(userId.toString()));
+        verify(userRepository).findById(userId);
+        verify(walletRepository, never()).save(any(Wallet.class));
+    }
+    
+    @Test
+    void shouldThrowExceptionWhenWalletAlreadyExists() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        Wallet existingWallet = new Wallet(UUID.randomUUID(), userId, null);
+        Wallet newWallet = new Wallet(null, userId, null);
+        User user = new User();
+        user.setId(userId);
+        
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(walletRepository.findByUserId(userId)).thenReturn(Optional.of(existingWallet));
+        
+        // Act & Assert
+        WalletAlreadyExistsException exception = assertThrows(
+            WalletAlreadyExistsException.class,
+            () -> service.create(newWallet)
+        );
+        
+        assertTrue(exception.getMessage().contains(userId.toString()));
+        verify(userRepository).findById(userId);
+        verify(walletRepository).findByUserId(userId);
+        verify(walletRepository, never()).save(any(Wallet.class));
     }
 }

--- a/src/test/java/com/recargapay/wallet/infra/NoSecurityTestConfig.java
+++ b/src/test/java/com/recargapay/wallet/infra/NoSecurityTestConfig.java
@@ -1,0 +1,34 @@
+package com.recargapay.wallet.infra;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class NoSecurityTestConfig {
+    @Bean
+    @Primary
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
+        return http.build();
+    }
+    
+    @Bean
+    @Primary
+    public AuthenticationManager testAuthenticationManager() {
+        return new AuthenticationManager() {
+            @Override
+            public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+                // Sempre retorna a autenticação fornecida como válida para testes
+                authentication.setAuthenticated(true);
+                return authentication;
+            }
+        };
+    }
+}

--- a/src/test/java/com/recargapay/wallet/infra/TestJwtConfig.java
+++ b/src/test/java/com/recargapay/wallet/infra/TestJwtConfig.java
@@ -1,0 +1,20 @@
+package com.recargapay.wallet.infra;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import javax.crypto.spec.SecretKeySpec;
+
+@TestConfiguration
+public class TestJwtConfig {
+    @Bean
+    @Primary
+    public JwtDecoder jwtDecoder(@Value("${spring.security.oauth2.resourceserver.jwt.secret}") String secret) {
+        SecretKeySpec secretKey = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(secretKey).build();
+    }
+}

--- a/src/test/java/com/recargapay/wallet/infra/TestSecurityConfig.java
+++ b/src/test/java/com/recargapay/wallet/infra/TestSecurityConfig.java
@@ -1,0 +1,23 @@
+package com.recargapay.wallet.infra;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+    
+    @Bean
+    @Primary
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        // Desabilita completamente a segurança para testes
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
+        
+        return http.build();
+    }
+}


### PR DESCRIPTION
fix: Deposit endpoint returning 500 Internal Server Error
### ModelMapper Configuration
- Added explicit ModelMapper configuration with STRICT matching strategy
- Enabled skipNullEnabled to prevent issues with null fields
- Implemented custom converters between TransactionType (enum) and String

### Transaction Mapper
- Removed generic ModelMapper usage that caused conversion errors
- Implemented explicit conversion methods in TransactionMapper
- Added specific handling for timestamp field in all conversions
- Correctly extracted wallet ID from wallet entity

### Architecture and Clean Design
- Removed improper repository dependency from TransactionMapper
- Moved entity relationship logic to TransactionRepositoryImpl
- Added WalletJpaRepository as dependency in transaction repository
- Implemented isolated toEntity method within the repository

### Error Handling
- Fixed null values in dates during conversions
- Properly handled relationship between TransactionEntity and WalletEntity
- Added null checking during object mapping

This fix maintains clean architecture integrity while resolving the 500 error in the /api/v1/wallets/deposit endpoint.